### PR TITLE
Change default settings behaviour

### DIFF
--- a/app/Actions/CreateHostAction.php
+++ b/app/Actions/CreateHostAction.php
@@ -24,21 +24,21 @@ class CreateHostAction
     public function __invoke(
         string $hostname,
         string $username,
-        array $options = []
+        bool $enabled,
+        int|null $port,
+        string|null $authorizedKeysFile,
+        array $groups = []
     ): Host {
-        /*
-         * These are optional values that can or can not be present.
-         * If they are not present, we use the database defaults.
-         */
-        $data = array_merge([
+        /* @var Host $host */
+        $host = Host::create([
             'hostname' => $hostname,
             'username' => $username,
-        ], $options);
+            'port' => $port,
+            'enabled' => $enabled,
+            'authorized_keys_file' => $authorizedKeysFile,
+        ]);
 
-        /* @var Host $host */
-        $host = Host::create($data);
-
-        $host->groups()->sync($options['groups'] ?? []);
+        $host->groups()->sync($groups);
 
         return $host;
     }

--- a/app/Actions/UpdateHostAction.php
+++ b/app/Actions/UpdateHostAction.php
@@ -23,15 +23,18 @@ class UpdateHostAction
 {
     public function __invoke(
         Host $host,
-        array $options,
+        bool $enabled,
+        int|null $port,
+        string|null $authorizedKeysFile,
+        array $groups = []
     ): Host {
         $host->update([
-            'port' => $options['port'] ?? $host->port,
-            'enabled' => $options['enabled'] ?? $host->enabled,
-            'authorized_keys_file' => $options['authorized_keys_file'] ?? $host->authorized_keys_file,
+            'port' => $port,
+            'enabled' => $enabled,
+            'authorized_keys_file' => $authorizedKeysFile,
         ]);
 
-        $host->groups()->sync($options['groups'] ?? []);
+        $host->groups()->sync($groups);
 
         return $host->refresh();
     }

--- a/app/Http/Controllers/HostController.php
+++ b/app/Http/Controllers/HostController.php
@@ -51,14 +51,13 @@ class HostController extends Controller
     public function store(HostCreateRequest $request, CreateHostAction $createHost): RedirectResponse
     {
         $host = $createHost(
-            $request->hostname(),
-            $request->username(),
-            [
-                'enabled' => $request->enabled(),
-                'port' => $request->port(),
-                'authorized_keys_file' => $request->authorized_keys_file(),
-                'groups' => $request->groups(),
-            ]);
+            hostname: $request->hostname(),
+            username: $request->username(),
+            enabled: $request->enabled(),
+            port: $request->port(),
+            authorizedKeysFile: $request->authorized_keys_file(),
+            groups: $request->groups()
+        );
 
         return redirect()->route('hosts.index')
             ->withSuccess(__('host/messages.create.success', ['hostname' => $host->full_hostname]));
@@ -83,13 +82,11 @@ class HostController extends Controller
     public function update(Host $host, HostUpdateRequest $request, UpdateHostAction $updateHost): RedirectResponse
     {
         $updateHost(
-            $host,
-            [
-                'enabled' => $request->enabled(),
-                'port' => $request->port(),
-                'authorized_keys_file' => $request->authorized_keys_file(),
-                'groups' => $request->groups(),
-            ]
+            host: $host,
+            enabled: $request->enabled(),
+            port: $request->port(),
+            authorizedKeysFile: $request->authorized_keys_file(),
+            groups: $request->groups()
         );
 
         return redirect()->route('hosts.index')

--- a/app/Http/Requests/HostCreateRequest.php
+++ b/app/Http/Requests/HostCreateRequest.php
@@ -76,17 +76,17 @@ class HostCreateRequest extends Request
 
     public function enabled(): bool
     {
-        return $this->boolean('enabled', true);
+        return $this->boolean('enabled');
     }
 
-    public function port(): int
+    public function port(): ?int
     {
-        return $this->input('port', 0);
+        return $this->input('port');
     }
 
-    public function authorized_keys_file(): string
+    public function authorized_keys_file(): ?string
     {
-        return $this->input('authorized_keys_file', '');
+        return $this->input('authorized_keys_file');
     }
 
     public function groups(): array

--- a/app/Http/Requests/HostUpdateRequest.php
+++ b/app/Http/Requests/HostUpdateRequest.php
@@ -68,7 +68,7 @@ class HostUpdateRequest extends Request
         return $this->input('groups', []);
     }
 
-    public function enabled(): ?bool
+    public function enabled(): bool
     {
         return $this->boolean('enabled');
     }

--- a/app/Jobs/UpdateServer.php
+++ b/app/Jobs/UpdateServer.php
@@ -30,7 +30,7 @@ class UpdateServer implements ShouldQueue
 
         $this->pusher = new SFTPPusher(
             $this->host->hostname,
-            $this->host->port,
+            $this->host->portOrDefaultSetting(),
             setting()->get('ssh_timeout'),
         );
     }

--- a/app/Models/Host.php
+++ b/app/Models/Host.php
@@ -86,28 +86,28 @@ class Host extends Model implements Searchable
     protected function username(): Attribute
     {
         return Attribute::make(
-            set: fn($value) => strtolower($value),
+            set: fn ($value) => strtolower($value),
         );
     }
 
     protected function hostname(): Attribute
     {
         return Attribute::make(
-            set: fn($value) => strtolower($value),
+            set: fn ($value) => strtolower($value),
         );
     }
 
     public function fullHostname(): Attribute
     {
         return Attribute::make(
-            get: fn($value, $attributes) => $attributes['username'] . '@' . $attributes['hostname'],
+            get: fn ($value, $attributes) => $attributes['username'].'@'.$attributes['hostname'],
         );
     }
 
     public function port(): Attribute
     {
         return Attribute::make(
-            set: fn($value) => (int) $value > 0 ? (int) $value : null,
+            set: fn ($value) => (int) $value > 0 ? (int) $value : null,
         );
     }
 
@@ -124,7 +124,7 @@ class Host extends Model implements Searchable
     public function authorizedKeysFile(): Attribute
     {
         return Attribute::make(
-            set: fn($value) => !empty($value) ? $value : null,
+            set: fn ($value) => ! empty($value) ? $value : null,
         );
     }
 
@@ -140,12 +140,12 @@ class Host extends Model implements Searchable
 
     public function hasCustomPort(): bool
     {
-        return !is_null($this->attributes['port']);
+        return ! is_null($this->attributes['port']);
     }
 
     public function hasCustomAuthorizedKeysFile(): bool
     {
-        return !is_null($this->attributes['authorized_keys_file']);
+        return ! is_null($this->attributes['authorized_keys_file']);
     }
 
     public function scopeNotInSync(Builder $query): Builder
@@ -194,7 +194,7 @@ class Host extends Model implements Searchable
                             break;
                         case ControlRuleAction::Allow:
                             $content = explode(' ', $key->public, 3);
-                            $content[2] = $key->username . '@ssham';
+                            $content[2] = $key->username.'@ssham';
                             $sshKeys[$key->username] = join(' ', $content);
                             break;
                         default:
@@ -203,7 +203,7 @@ class Host extends Model implements Searchable
                 }
             }
         }
-        if (!is_null($bastionSSHPublicKey)) {
+        if (! is_null($bastionSSHPublicKey)) {
             $sshKeys[] = $bastionSSHPublicKey;
         }
 

--- a/app/Presenters/HostPresenter.php
+++ b/app/Presenters/HostPresenter.php
@@ -66,7 +66,7 @@ class HostPresenter extends Presenter
 
     public function portDefaultSetting(): string
     {
-        return $this->model->portDefaultSetting();
+        return sprintf('%d', $this->model->portDefaultSetting());
     }
 
     public function authorizedKeysFileDefaultSetting(): string

--- a/app/Presenters/HostPresenter.php
+++ b/app/Presenters/HostPresenter.php
@@ -63,4 +63,14 @@ class HostPresenter extends Presenter
     {
         return sprintf('%d', $this->model->port);
     }
+
+    public function portDefaultSetting(): string
+    {
+        return $this->model->portDefaultSetting();
+    }
+
+    public function authorizedKeysFileDefaultSetting(): string
+    {
+        return $this->model->authorizedKeysFileDefaultSetting();
+    }
 }

--- a/resources/views/host/_details.blade.php
+++ b/resources/views/host/_details.blade.php
@@ -41,10 +41,13 @@
                         <strong>@lang('host/model.port')</strong>
                     </dt>
                     <dd class="col-sm-9">
-                        {{ $host->present()->port }}
-                        @unless($host->hasCustomPort())
+
+                        @if($host->hasCustomPort())
+                            {{ $host->present()->port }}
+                        @else
+                            {{ $host->present()->portDefaultSetting() }}
                             (set by <a href="{{ route('settings.index') }}">settings</a>)
-                        @endunless
+                        @endif
                     </dd>
                     <!-- ./ port -->
 
@@ -54,7 +57,10 @@
                     </dt>
                     <dd class="col-sm-9">
                         {{ $host->present()->authorized_keys_file }}
-                        @unless($host->hasCustomAuthorizedKeysFile())
+                        @if($host->hasCustomAuthorizedKeysFile())
+                            {{ $host->present()->authorized_keys_file }}
+                        @else
+                            {{ $host->present()->authorizedKeysFileDefaultSetting() }}
                             (set by <a href="{{ route('settings.index') }}">settings</a>)
                         @endunless
                     </dd>
@@ -156,7 +162,8 @@
 
     </div>
     <div class="card-footer">
-        <a href="{{ route('hosts.edit', $host->id) }}" class="btn btn-primary @cannot('update', $host) disabled @endcannot" role="button">
+        <a href="{{ route('hosts.edit', $host->id) }}"
+           class="btn btn-primary @cannot('update', $host) disabled @endcannot" role="button">
             @lang('general.edit')
         </a>
         <a href="{{ route('hosts.index') }}" class="btn btn-link" role="button">

--- a/tests/Feature/Actions/UpdateHostActionTest.php
+++ b/tests/Feature/Actions/UpdateHostActionTest.php
@@ -18,10 +18,8 @@
 
 namespace Tests\Feature\Actions;
 
-use App\Actions\CreateHostAction;
 use App\Actions\UpdateHostAction;
 use App\Models\Host;
-use App\Models\Hostgroup;
 use Generator;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -32,44 +30,55 @@ class UpdateHostActionTest extends TestCase
 
     /**
      * @test
-     * @dataProvider providesHostData
+     * @dataProvider provideNullableFieldsForHosts
      */
     public function it_can_update_a_host(
-        array $options,
+        array $nullable,
     ): void {
+        $action = app(UpdateHostAction::class);
+
         /** @var Host $host */
         $host = Host::factory()
             ->customized()
             ->create();
 
-        $action = app(UpdateHostAction::class);
+        /** @var Host $want */
+        $want = Host::factory()->make();
 
         $action(
             host: $host,
-            options: $options,
+            enabled: $want->enabled,
+            port: $nullable['port'] ?? $want->port,
+            authorizedKeysFile: $nullable['authorized_keys_file'] ?? $want->authorized_keys_file,
+            groups: [],
         );
 
         $this->assertDatabaseHas(Host::class, [
             'hostname' => $host->hostname,
             'username' => $host->username,
-            'enabled' => $options['enabled'] ?? $host->enabled,
-            'port' => $options['port'] ?? $host->port,
-            'authorized_keys_file' => $options['authorized_keys_file'] ?? $host->authorized_keys_file,
+            'enabled' => $want->enabled,
+            'port' => $nullable['port'] ?? $want->port,
+            'authorized_keys_file' => $nullable['authorized_keys_file'] ?? $want->authorized_keys_file,
         ]);
     }
 
-    public function providesHostData(): Generator
+    public function provideNullableFieldsForHosts(): Generator
     {
-        yield 'empty options' => [
-            'options' => [],
+        yield 'without null values' => [
+            'nullable' => [],
         ];
 
-        yield 'custom options' => [
-            'options' => [
-                'enabled' => true,
-                'port' => 2022,
-                'authorized_keys_file' => 'custom_authorized_keys_file',
+        yield 'null port' => [
+            'nullable' => [
+                'port' => null,
             ],
         ];
+
+        yield 'null authorized_keys_file' => [
+            'nullable' => [
+                'authorized_keys_file' => null,
+            ],
+        ];
+
     }
 }

--- a/tests/Feature/Actions/UpdateHostActionTest.php
+++ b/tests/Feature/Actions/UpdateHostActionTest.php
@@ -79,6 +79,5 @@ class UpdateHostActionTest extends TestCase
                 'authorized_keys_file' => null,
             ],
         ];
-
     }
 }

--- a/tests/Feature/Http/Api/ApiHostsTest.php
+++ b/tests/Feature/Http/Api/ApiHostsTest.php
@@ -296,7 +296,7 @@ class ApiHostsTest extends ApiTestCase
             'attributes' => [
                 'hostname' => $host->hostname,
                 'username' => $host->username,
-                'port' => (string) $host->port,
+                'port' => $host->port,
                 'fullHostname' => $host->full_hostname,
                 'authorizedKeysFile' => $host->authorized_keys_file,
                 'enabled' => $host->enabled,

--- a/tests/Feature/Models/HostTest.php
+++ b/tests/Feature/Models/HostTest.php
@@ -247,7 +247,7 @@ class HostTest extends TestCase
             'port' => $attributes['port'],
         ]);
 
-        $this->assertEquals($want, $host->port);
+        $this->assertEquals($want, $host->portOrDefaultSetting());
     }
 
     public function provideGetPortTestCases(): Generator
@@ -313,7 +313,7 @@ class HostTest extends TestCase
             'authorized_keys_file' => $attributes['authorized_keys_file'],
         ]);
 
-        $this->assertEquals($want, $host->authorized_keys_file);
+        $this->assertEquals($want, $host->authorizedKeysFileOrDefaultSetting());
     }
 
     public function provideGetAuthorizedKeysFileTestCases(): Generator


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind enhancement

**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
Before this PR the default settings for `port` and `authorized_keys_file` where stored in the database. It makes useless having the changing this settings, while the database will remain the old value.

With the change, we are storing `null` values, which mean that the value has not been set and the settings values should be used.