### PR TITLE
Allow the use of plain strings as SSH key comments

### DIFF
--- a/app/Actions/CreateKeyAction.php
+++ b/app/Actions/CreateKeyAction.php
@@ -22,13 +22,13 @@ use App\Models\Key;
 class CreateKeyAction
 {
     public function __invoke(
-        string $username,
+        string $name,
         string $publicKey,
         string|null $privateKey,
         array $groups,
     ): Key {
         $key = Key::create([
-            'username' => $username,
+            'name' => $name,
             'public' => $publicKey,
             'private' => $privateKey,
         ]);

--- a/app/Http/Controllers/KeyController.php
+++ b/app/Http/Controllers/KeyController.php
@@ -65,14 +65,14 @@ class KeyController extends Controller
         }
 
         $key = $createKey(
-            username: $request->username(),
+            name: $request->name(),
             publicKey: $publicKey,
             privateKey: $privateKey,
             groups: $request->groups()
         );
 
         return redirect()->route('keys.show', $key)
-            ->with('success', __('key/messages.create.success', ['username' => $key->username]));
+            ->with('success', __('key/messages.create.success', ['name' => $key->name]));
     }
 
     public function show(Key $key): View
@@ -115,23 +115,23 @@ class KeyController extends Controller
         );
 
         return redirect()->route('keys.show', $key)
-            ->with('success', __('key/messages.edit.success', ['username' => $key->username]));
+            ->with('success', __('key/messages.edit.success', ['name' => $key->name]));
     }
 
     public function destroy(Key $key): RedirectResponse
     {
-        $username = $key->username;
+        $name = $key->name;
 
         try {
             $key->delete();
         } catch (Throwable $exception) {
-            Log::error("Key '$key->username' was not deleted: {$exception->getMessage()}");
+            Log::error("Key '$key->name' was not deleted: {$exception->getMessage()}");
 
             return redirect()->back()
                 ->withErrors(trans('key/messages.delete.error'));
         }
 
         return redirect()->route('keys.index')
-            ->with('success', __('key/messages.delete.success', ['username' => $username]));
+            ->with('success', __('key/messages.delete.success', ['name' => $name]));
     }
 }

--- a/app/Http/Controllers/KeyDataTablesController.php
+++ b/app/Http/Controllers/KeyDataTablesController.php
@@ -31,16 +31,16 @@ class KeyDataTablesController extends Controller
         $keys = Key::query()
             ->select([
                 'id',
-                'username',
+                'name',
                 'fingerprint',
                 'enabled',
             ])
             ->withCount('groups as groups') // count number of groups without loading the models
-            ->orderBy('username');
+            ->orderBy('name');
 
         return $dataTable->eloquent($keys)
-            ->editColumn('username', function (Key $key) {
-                return $key->present()->usernameWithDisabledBadge();
+            ->editColumn('name', function (Key $key) {
+                return $key->present()->nameWithDisabledBadge();
             })
             ->editColumn('enabled', function (Key $key) {
                 return $key->present()->enabledAsBadge();
@@ -51,7 +51,7 @@ class KeyDataTablesController extends Controller
                     ->with('model', $key)
                     ->render();
             })
-            ->rawColumns(['username', 'enabled', 'actions'])
+            ->rawColumns(['name', 'enabled', 'actions'])
             ->removeColumn('id')
             ->toJson();
     }

--- a/app/Http/Controllers/KeygroupController.php
+++ b/app/Http/Controllers/KeygroupController.php
@@ -42,7 +42,7 @@ class KeygroupController extends Controller
     public function create(): View
     {
         // Get all existing keys
-        $keys = Key::orderBy('username')->pluck('username', 'id');
+        $keys = Key::orderBy('name')->pluck('name', 'id');
 
         return view('keygroup.create')
             ->with('keys', $keys);
@@ -71,7 +71,7 @@ class KeygroupController extends Controller
     public function edit(Keygroup $keygroup): View
     {
         // Get all existing keys
-        $keys = Key::orderBy('username')->pluck('username', 'id');
+        $keys = Key::orderBy('name')->pluck('name', 'id');
 
         return view('keygroup.edit')
             ->with('keygroup', $keygroup)

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -50,7 +50,7 @@ class SearchController extends Controller
         return (new Search())
             ->registerModel(Key::class, function (ModelSearchAspect $modelSearchAspect) {
                 $modelSearchAspect
-                    ->addSearchableAttribute('username') // return results for partial matches on usernames
+                    ->addSearchableAttribute('name') // return results for partial matches on key names
                     ->addExactSearchableAttribute('fingerprint'); // only return results that exactly match the fingerprint
             })
             ->registerModel(Keygroup::class, 'name', 'description')

--- a/app/Http/Requests/KeyCreateRequest.php
+++ b/app/Http/Requests/KeyCreateRequest.php
@@ -30,9 +30,10 @@ class KeyCreateRequest extends Request
     public function rules(): array
     {
         return [
-            'username' => [
+            'name' => [
                 'required',
-                new UsernameRule(),
+                'string',
+                'max:255',
                 Rule::unique(Key::class),
             ],
             'operation' => [
@@ -54,9 +55,9 @@ class KeyCreateRequest extends Request
         return $this->input('operation') === KeyOperation::IMPORT_OPERATION;
     }
 
-    public function username(): string
+    public function name(): string
     {
-        return $this->input('username');
+        return $this->input('name');
     }
 
     public function publicKey(): string

--- a/app/Listeners/RemovePrivateKey.php
+++ b/app/Listeners/RemovePrivateKey.php
@@ -32,6 +32,6 @@ class RemovePrivateKey
         activity()
             //->performedOn($key)
             ->withProperties(['status' => ActivityStatus::Success])
-            ->log(sprintf("Private key was removed from key '%s'.", $key->username));
+            ->log(sprintf("Private key was removed from key '%s'.", $key->name));
     }
 }

--- a/app/Models/Host.php
+++ b/app/Models/Host.php
@@ -196,7 +196,7 @@ class Host extends Model implements Searchable
                             break;
                         case ControlRuleAction::Allow:
                             $content = explode(' ', $key->public, 3);
-                            $content[2] = $key->name.'@ssham';
+                            $content[2] = 'ssham: ' . $key->name;
                             $sshKeys[$key->name] = implode(' ', $content);
                             break;
                         default:

--- a/app/Models/Host.php
+++ b/app/Models/Host.php
@@ -192,12 +192,12 @@ class Host extends Model implements Searchable
                 foreach ($keys as $key) {
                     switch ($rule->action) {
                         case ControlRuleAction::Deny:
-                            unset($sshKeys[$key->username]);
+                            unset($sshKeys[$key->name]);
                             break;
                         case ControlRuleAction::Allow:
                             $content = explode(' ', $key->public, 3);
-                            $content[2] = $key->username.'@ssham';
-                            $sshKeys[$key->username] = implode(' ', $content);
+                            $content[2] = $key->name.'@ssham';
+                            $sshKeys[$key->name] = implode(' ', $content);
                             break;
                         default:
                             // There is no more cases, but just in case (NOOP).

--- a/app/Models/Key.php
+++ b/app/Models/Key.php
@@ -34,7 +34,7 @@ use Spatie\Searchable\SearchResult;
  * Class Key.
  *
  * @property string                          $id
- * @property string                          $username
+ * @property string                          $name
  * @property bool                            $enabled
  * @property string                          $type
  * @property string                          $public
@@ -58,7 +58,7 @@ class Key extends Model implements Searchable
     protected $table = 'keys';
 
     protected $fillable = [
-        'username',
+        'name',
         'public',
         'private',
         'enabled',
@@ -74,13 +74,6 @@ class Key extends Model implements Searchable
     public function groups(): BelongsToMany
     {
         return $this->belongsToMany(Keygroup::class);
-    }
-
-    protected function username(): Attribute
-    {
-        return Attribute::make(
-            set: fn ($value) => strtolower($value),
-        );
     }
 
     protected function public(): Attribute
@@ -99,7 +92,7 @@ class Key extends Model implements Searchable
 
         return new SearchResult(
             $this,
-            $this->username,
+            $this->name,
             $url
         );
     }
@@ -113,9 +106,9 @@ class Key extends Model implements Searchable
     public function getActivitylogOptions(): LogOptions
     {
         return LogOptions::defaults()
-            ->logOnly(['username', 'enabled'])
+            ->logOnly(['name', 'enabled'])
             ->logOnlyDirty()
-            ->setDescriptionForEvent(fn (string $eventName) => "Key ':subject.username' was {$eventName}");
+            ->setDescriptionForEvent(fn (string $eventName) => "Key ':subject.name' was {$eventName}");
     }
 
     /** @codeCoverageIgnore */

--- a/app/Presenters/KeyPresenter.php
+++ b/app/Presenters/KeyPresenter.php
@@ -35,13 +35,13 @@ class KeyPresenter extends Presenter
         return optional($this->model->updated_at)->diffForHumans() ?? 'N/A';
     }
 
-    public function usernameWithDisabledBadge(): HtmlString
+    public function nameWithDisabledBadge(): HtmlString
     {
         $badge = $this->enabledAsBadge();
 
         return $this->model->enabled
-            ? new HtmlString($this->model->username)
-            : new HtmlString($this->model->username.' '.$badge);
+            ? new HtmlString($this->model->name)
+            : new HtmlString($this->model->name.' '.$badge);
     }
 
     public function enabledAsBadge(): HtmlString

--- a/database/factories/KeyFactory.php
+++ b/database/factories/KeyFactory.php
@@ -40,7 +40,7 @@ class KeyFactory extends Factory
         $publicKey = $privateKey->getPublicKey();
 
         return [
-            'username' => fake()->unique()->userName,
+            'name' => fake()->unique()->userName,
             'public' => (string) $publicKey,
             'private' => (string) $privateKey,
             'enabled' => true,

--- a/database/migrations/2014_10_12_100000_create_keys_table.php
+++ b/database/migrations/2014_10_12_100000_create_keys_table.php
@@ -26,7 +26,7 @@ return new class extends Migration
     {
         Schema::create('keys', function (Blueprint $table) {
             $table->uuid('id')->primary();
-            $table->string('username')->unique();
+            $table->string('name')->unique();
             $table->text('type')->nullable();
             $table->text('length')->nullable();
             $table->text('public')->nullable();

--- a/lang/en/key/messages.php
+++ b/lang/en/key/messages.php
@@ -18,7 +18,7 @@
 
 return [
 
-    'username_help' => 'For security reasons, username <strong>cannot</strong> be changed once the key is created.',
+    'name_help' => 'For security reasons, name <strong>cannot</strong> be changed once the key is created.',
 
     'private_key_available' => 'Private key is available',
     'download_private_key' => 'Download private key',
@@ -36,21 +36,21 @@ return [
 
     'create' => [
         'error' => 'Key was not created, please try again.',
-        'success' => 'The key \':username\' was created successfully.',
+        'success' => 'The key \':name\' was created successfully.',
     ],
     'edit' => [
         'error' => 'There was an issue editing the key. Please try again.',
-        'success' => 'The key \':username\' was edited successfully.',
+        'success' => 'The key \':name\' was edited successfully.',
     ],
     'delete' => [
         'error' => 'There was an issue deleting the key. Please try again.',
-        'success' => 'The key \':username\' was deleted successfully.',
+        'success' => 'The key \':name\' was deleted successfully.',
     ],
 
     'danger_zone_section' => 'Danger Zone',
     'delete_button' => 'Delete this SSH key',
     'delete_help' => 'Once you delete a SSH key, there is no going back. Please be certain.',
-    'delete_confirmation_warning' => 'This action <strong>cannot</strong> be undone. This will permanently delete the <strong>:username</strong> SSH key and remove all group associations.',
+    'delete_confirmation_warning' => 'This action <strong>cannot</strong> be undone. This will permanently delete the <strong>:name</strong> SSH key and remove all group associations.',
     'delete_confirmation_button' => 'I understand the consequences, delete this SSH key',
     'delete_avoided' => 'You are not allowed to delete this key.',
 

--- a/lang/en/key/model.php
+++ b/lang/en/key/model.php
@@ -24,7 +24,7 @@ return [
     |
     */
     'item' => 'SSH Keys',
-    'username' => 'Username',
+    'name' => 'Name',
     'public_key' => 'SSH public key',
     'private_key' => 'Private key',
     'fingerprint' => 'Key fingerprint',

--- a/lang/en/key/table.php
+++ b/lang/en/key/table.php
@@ -17,7 +17,7 @@
  */
 
 return [
-    'username' => 'Username',
+    'name' => 'Name',
     'groups' => 'Groups',
     'enabled' => 'Status',
     'fingerprint' => 'Fingerprint',

--- a/resources/views/key/_details.blade.php
+++ b/resources/views/key/_details.blade.php
@@ -1,7 +1,7 @@
 <div class="card">
     <div class="card-header @unless($key->enabled) bg-gray-dark @endunless">
         <h2 class="card-title">
-            {{ $key->present()->username }}
+            {{ $key->present()->name }}
             @unless($key->enabled)
                 {{ $key->present()->enabledAsBadge() }}
             @endunless
@@ -16,14 +16,14 @@
                 <h3>@lang('key/title.key_identification_section')</h3>
                 <dl class="row">
 
-                    <!-- username -->
+                    <!-- name -->
                     <dt class="col-sm-3">
-                        <strong>@lang('key/model.username')</strong>
+                        <strong>@lang('key/model.name')</strong>
                     </dt>
                     <dd class="col-sm-9">
-                        {{ $key->present()->username }}
+                        {{ $key->present()->name }}
                     </dd>
-                    <!-- ./ username -->
+                    <!-- ./ name -->
 
                     <!-- fingerprint -->
                     <dt class="col-sm-3">
@@ -166,11 +166,11 @@
     <!-- confirmation modal -->
     <x-modals.confirmation
         action="{{ route('keys.destroy', $key) }}"
-        confirmationText="{{ $key->username }}"
+        confirmationText="{{ $key->name }}"
         buttonText="{{ __('key/messages.delete_confirmation_button') }}">
 
         <div class="alert alert-warning" role="alert">
-            @lang('key/messages.delete_confirmation_warning', ['username' => $key->username])
+            @lang('key/messages.delete_confirmation_warning', ['name' => $key->name])
         </div>
     </x-modals.confirmation>
     <!-- ./ confirmation modal -->

--- a/resources/views/key/_table.blade.php
+++ b/resources/views/key/_table.blade.php
@@ -7,7 +7,7 @@
 <table id="keys-table" class="table table-bordered table-hover">
     <thead>
     <tr>
-        <th>@lang('key/table.username')</th>
+        <th>@lang('key/table.name')</th>
         <th>@lang('key/table.fingerprint')</th>
         <th>@lang('key/table.groups')</th>
         <th>@lang('key/table.enabled')</th>
@@ -16,7 +16,7 @@
     </thead>
     <tfoot>
     <tr>
-        <th>@lang('key/table.username')</th>
+        <th>@lang('key/table.name')</th>
         <th>@lang('key/table.fingerprint')</th>
         <th>@lang('key/table.groups')</th>
         <th>@lang('key/table.enabled')</th>
@@ -34,7 +34,7 @@
             $('#keys-table').DataTable({
                 "ajax": "{{ route('keys.data') }}",
                 "columns": [
-                    {data: "username"},
+                    {data: "name"},
                     {data: "fingerprint", "orderable": false, "searchable": true},
                     {data: "groups", "orderable": false, "searchable": false},
                     {data: "enabled"},

--- a/resources/views/key/create.blade.php
+++ b/resources/views/key/create.blade.php
@@ -40,15 +40,15 @@
 
                     <fieldset>
                         <legend>@lang('key/title.key_identification_section')</legend>
-                        <!-- username -->
-                        <x-form-input name="username" :label="__('key/model.username')" required autofocus>
+                        <!-- name -->
+                        <x-form-input name="name" :label="__('key/model.name')" required autofocus>
                             @slot('help')
                                 <small class="form-text text-muted">
-                                    @lang('key/messages.username_help')
+                                    @lang('key/messages.name_help')
                                 </small>
                             @endslot
                         </x-form-input>
-                        <!-- ./ username -->
+                        <!-- ./ name -->
                     </fieldset>
 
                     <!-- SSH public key -->

--- a/resources/views/key/edit.blade.php
+++ b/resources/views/key/edit.blade.php
@@ -33,7 +33,7 @@
 
         <div class="card-header @unless($key->enabled) bg-gray-dark @endunless">
             <h2 class="card-title">
-                {{ $key->username }}
+                {{ $key->name }}
                 @unless($key->enabled)
                     {{ $key->present()->enabledAsBadge() }}
                 @endunless
@@ -47,15 +47,15 @@
 
                     <fieldset>
                         <legend>@lang('key/title.key_identification_section')</legend>
-                        <!-- username -->
-                        <x-form-input name="username" :label="__('key/model.username')" :value="$key->username" readonly>
+                        <!-- name -->
+                        <x-form-input name="name" :label="__('key/model.name')" :value="$key->name" readonly>
                             @slot('help')
                                 <small class="form-text text-muted">
-                                    @lang('key/messages.username_help')
+                                    @lang('key/messages.name_help')
                                 </small>
                             @endslot
                         </x-form-input>
-                        <!-- ./ username -->
+                        <!-- ./ name -->
                     </fieldset>
 
                     <!-- enabled -->
@@ -212,11 +212,11 @@
     <!-- confirmation modal -->
     <x-modals.confirmation
         action="{{ route('keys.destroy', $key) }}"
-        confirmationText="{{ $key->username }}"
+        confirmationText="{{ $key->name }}"
         buttonText="{{ __('key/messages.delete_confirmation_button') }}">
 
         <div class="alert alert-warning" role="alert">
-            @lang('key/messages.delete_confirmation_warning', ['username' => $key->username])
+            @lang('key/messages.delete_confirmation_warning', ['name' => $key->name])
         </div>
 
     </x-modals.confirmation>

--- a/tests/Feature/Http/Controllers/KeyControllerTest.php
+++ b/tests/Feature/Http/Controllers/KeyControllerTest.php
@@ -132,13 +132,13 @@ class KeyControllerTest extends TestCase
         $this
             ->actingAs($this->user)
             ->post(route('keys.store'), [
-                'username' => $want->username,
+                'name' => $want->name,
                 'operation' => KeyOperation::CREATE_OPERATION,
             ])
             ->assertForbidden();
 
         $this->assertDatabaseMissing(Key::class, [
-            'username' => $want->username,
+            'name' => $want->name,
         ]);
     }
 
@@ -160,7 +160,7 @@ class KeyControllerTest extends TestCase
         $want = Key::factory()->make();
 
         $formData = array_merge([
-            'username' => $want->username,
+            'name' => $want->name,
             'operation' => KeyOperation::CREATE_OPERATION,
             'groups' => $groups->pluck('id')->toArray(),
         ], $data);
@@ -171,7 +171,7 @@ class KeyControllerTest extends TestCase
             ->assertValid();
 
         $key = Key::query()
-            ->where('username', $want->username)
+            ->where('name', $want->name)
             ->first();
 
         $this->assertInstanceOf(Key::class, $key);
@@ -218,14 +218,14 @@ class KeyControllerTest extends TestCase
 
         // Key to validate unique rules...
         Key::factory()->create([
-            'username' => 'foo',
+            'name' => 'foo',
         ]);
 
         /** @var Key $want */
         $want = Key::factory()->make();
 
         $formData = [
-            'username' => $data['username'] ?? $want->username,
+            'name' => $data['name'] ?? $want->name,
             'operation' => $data['operation'] ?? KeyOperation::CREATE_OPERATION,
         ];
 
@@ -234,41 +234,34 @@ class KeyControllerTest extends TestCase
             ->post(route('keys.store'), $formData)
             ->assertInvalid($errors);
 
-        if ($formData['username'] != 'foo') {
+        if ($formData['name'] != 'foo') {
             $this->assertDatabaseMissing(Key::class, [
-                'username' => $formData['username'],
+                'name' => $formData['name'],
             ]);
         }
     }
 
     public static function provideWrongDataForKeyCreation(): Generator
     {
-        yield 'username is empty' => [
+        yield 'name is empty' => [
             'data' => [
-                'username' => '',
+                'name' => '',
             ],
-            'errors' => ['username'],
+            'errors' => ['name'],
         ];
 
-        yield 'username > 255 chars' => [
+        yield 'name > 255 chars' => [
             'data' => [
-                'username' => '0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345',
+                'name' => '0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345',
             ],
-            'errors' => ['username'],
+            'errors' => ['name'],
         ];
 
-        yield 'username ! valid' => [
+        yield 'name is taken' => [
             'data' => [
-                'username' => '_foo34',
+                'name' => 'foo',
             ],
-            'errors' => ['username'],
-        ];
-
-        yield 'username is taken' => [
-            'data' => [
-                'username' => 'foo',
-            ],
-            'errors' => ['username'],
+            'errors' => ['name'],
         ];
 
         yield 'operation ! valid' => [
@@ -420,7 +413,7 @@ class KeyControllerTest extends TestCase
 
         $this->assertDatabaseMissing(Key::class, [
             'id' => $key->id,
-            'username' => $key->username,
+            'name' => $key->name,
             'enabled' => $formData['enabled'],
             'public' => $formData['public_key'],
         ]);

--- a/tests/Feature/Http/Controllers/KeyDataTablesControllerTest.php
+++ b/tests/Feature/Http/Controllers/KeyDataTablesControllerTest.php
@@ -81,7 +81,7 @@ class KeyDataTablesControllerTest extends TestCase
             ->assertJsonStructure([
                 'data' => [
                     '*' => [
-                        'username',
+                        'name',
                         'fingerprint',
                         'groups',
                         'actions',

--- a/tests/Feature/Http/Controllers/KeygroupControllerTest.php
+++ b/tests/Feature/Http/Controllers/KeygroupControllerTest.php
@@ -113,7 +113,7 @@ class KeygroupControllerTest extends TestCase
             ->get(route('keygroups.create'))
             ->assertSuccessful()
             ->assertViewIs('keygroup.create')
-            ->assertViewHas('keys', $keys->pluck('username', 'id'));
+            ->assertViewHas('keys', $keys->pluck('name', 'id'));
     }
 
     /** @test */
@@ -274,7 +274,7 @@ class KeygroupControllerTest extends TestCase
             ->assertSuccessful()
             ->assertViewIs('keygroup.edit')
             ->assertViewHas('keygroup', $group)
-            ->assertViewHas('keys', $keys->pluck('username', 'id'));
+            ->assertViewHas('keys', $keys->pluck('name', 'id'));
     }
 
     /** @test */

--- a/tests/Feature/Http/Controllers/SearchControllerTest.php
+++ b/tests/Feature/Http/Controllers/SearchControllerTest.php
@@ -41,7 +41,7 @@ class SearchControllerTest extends TestCase
     public function users_should_see_the_search_view(): void
     {
         Key::factory()->create([
-            'username' => 'qwerty_key',
+            'name' => 'qwerty_key',
         ]);
 
         $this
@@ -55,7 +55,7 @@ class SearchControllerTest extends TestCase
     public function users_should_see_the_search_view_when_using_an_empty_query(): void
     {
         Key::factory()->create([
-            'username' => 'qwerty_key',
+            'name' => 'qwerty_key',
         ]);
 
         $this
@@ -74,7 +74,7 @@ class SearchControllerTest extends TestCase
         array $want,
     ): void {
         Key::factory()->create([
-            'username' => 'qwerty_key',
+            'name' => 'qwerty_key',
         ]);
         Host::factory()->create([
             'hostname' => 'qwerty_host',

--- a/tests/Feature/Models/HostTest.php
+++ b/tests/Feature/Models/HostTest.php
@@ -86,8 +86,8 @@ class HostTest extends TestCase
         $hostGroup->hosts()->save($host);
 
         // These two keys should appear on the getSSHKeysForHost() list.
-        $key1 = Key::factory()->create(['username' => 'key1']);
-        $key2 = Key::factory()->create(['username' => 'key2']);
+        $key1 = Key::factory()->create(['name' => 'key1']);
+        $key2 = Key::factory()->create(['name' => 'key2']);
         $allowedKeyGroup = Keygroup::factory()->create();
         $allowedKeyGroup->keys()->saveMany([
             $key1,
@@ -117,9 +117,9 @@ class HostTest extends TestCase
 
         $got = $host->getSSHKeysForHost();
         $this->assertCount(2, $got);
-        $this->assertArrayHasKey($key1->username, $got);
-        $this->assertArrayHasKey($key2->username, $got);
-        $this->assertArrayNotHasKey($key3->username, $got);
+        $this->assertArrayHasKey($key1->name, $got);
+        $this->assertArrayHasKey($key2->name, $got);
+        $this->assertArrayNotHasKey($key3->name, $got);
     }
 
     /** @test */
@@ -130,7 +130,7 @@ class HostTest extends TestCase
         $hostGroup = Hostgroup::factory()->create();
         $hostGroup->hosts()->save($host);
 
-        $key1 = Key::factory()->create(['username' => 'key1']);
+        $key1 = Key::factory()->create(['name' => 'key1']);
         $allowedKeyGroup = Keygroup::factory()->create();
         $allowedKeyGroup->keys()->save($key1);
 
@@ -164,9 +164,9 @@ class HostTest extends TestCase
         $hostGroup->hosts()->save($host);
 
         // This key should appear on the getSSHKeysForHost() list.
-        $key1 = Key::factory()->create(['username' => 'key1']);
+        $key1 = Key::factory()->create(['name' => 'key1']);
         // This key should NOT appear, because is disabled, on the getSSHKeysForHost() list.
-        $key2 = Key::factory()->create(['username' => 'key2', 'enabled' => false]);
+        $key2 = Key::factory()->create(['name' => 'key2', 'enabled' => false]);
         $allowedKeyGroup = Keygroup::factory()->create();
         $allowedKeyGroup->keys()->saveMany([
             $key1,
@@ -182,8 +182,8 @@ class HostTest extends TestCase
 
         $got = $host->getSSHKeysForHost();
         $this->assertCount(1, $got);
-        $this->assertArrayHasKey($key1->username, $got);
-        $this->assertArrayNotHasKey($key2->username, $got);
+        $this->assertArrayHasKey($key1->name, $got);
+        $this->assertArrayNotHasKey($key2->name, $got);
     }
 
     /** @test */
@@ -194,7 +194,7 @@ class HostTest extends TestCase
         $hostGroup = Hostgroup::factory()->create();
         $hostGroup->hosts()->save($host);
 
-        $key1 = Key::factory()->create(['username' => 'key1']);
+        $key1 = Key::factory()->create(['name' => 'key1']);
         $allowedKeyGroup = Keygroup::factory()->create();
         $allowedKeyGroup->keys()->save($key1);
 

--- a/tests/Unit/Models/KeyTest.php
+++ b/tests/Unit/Models/KeyTest.php
@@ -27,7 +27,7 @@ class KeyTest extends ModelTestCase
     {
         $m = new Key();
         $this->assertEquals([
-            'username',
+            'name',
             'public',
             'private',
             'enabled',


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind feature

**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
resolves #353 


**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
Yes, key's names are not usernames anymore, even though you can use them
